### PR TITLE
add AnalogControlBipolar to patchsm

### DIFF
--- a/src/json2daisy/resources/component_defs_patchsm.json
+++ b/src/json2daisy/resources/component_defs_patchsm.json
@@ -176,6 +176,27 @@
 			}
 		]
 	},
+	"AnalogControlBipolar": {
+		"init_single": "cfg[{i}].InitSingle(som.GetPin({pin}));",
+		"map_init": "{name}.InitBipolarCv(som.adc.GetPtr({i}), som.AudioCallbackRate());",
+		"typename": "daisy::AnalogControl",
+		"direction": "in",
+		"pin": "a",
+		"slew": "1.0/som.AudioCallbackRate()",
+		"process": "{name}.Process();",
+		"updaterate": "{name}.SetSampleRate(som.AudioCallbackRate());",
+		"mapping": [
+			{
+				"name": "{name}",
+				"get": "({class_name}.{name}.Value())",
+				"range": [
+					0,
+					1
+				],
+				"bool": false
+			}
+		]
+	},
 	"Led": {
 		"map_init": "{name}.Init(daisy::patch_sm::DaisyPatchSM::{pin}, {invert});\n\t\t{name}.Set(0.0f);",
 		"typename": "daisy::Led",


### PR DESCRIPTION
The other day when we tried to build the estuary json and the build failed, it was because for some reason the seed definition file has `AnalogControlBipolar` defined, but the patch definition file does not. I have no idea why that was the case, but it was easy enough to copy that over and everything seems to be building fine now