### PR TITLE
additional fixes to build on patch

### DIFF
--- a/src/json2daisy/json2daisy.py
+++ b/src/json2daisy/json2daisy.py
@@ -178,7 +178,7 @@ def generate_header(board_description_dict: dict) -> 'tuple[str, dict]':
         raise NameError(f'Unkown som "{som}"')
 
     # alphabetize by component name
-    components = sorted(components.items(), key=lambda x: x[1]['component'])
+    components = sorted(components.items(), key=lambda x: x[1]['component'] + x[0])
     components = list(map(map_load, components))
 
     # flatten pin dicts into multiple entries

--- a/src/json2daisy/resources/component_defs_patchsm.json
+++ b/src/json2daisy/resources/component_defs_patchsm.json
@@ -127,7 +127,7 @@
 		]
 	},
 	"GateIn": {
-		"map_init": "{name}.Init(&daisy::patch_sm::DaisyPatchSM::{pin});",
+		"map_init": "{name}.Init(daisy::patch_sm::DaisyPatchSM::{pin});",
 		"typename": "daisy::GateIn",
 		"direction": "in",
 		"pin": "a",
@@ -177,7 +177,7 @@
 		]
 	},
 	"AnalogControlBipolar": {
-		"init_single": "cfg[{i}].InitSingle(som.GetPin({pin}));",
+		"init_single": "cfg[{i}].InitSingle(daisy::patch_sm::DaisyPatchSM::{pin});",
 		"map_init": "{name}.InitBipolarCv(som.adc.GetPtr({i}), som.AudioCallbackRate());",
 		"typename": "daisy::AnalogControl",
 		"direction": "in",
@@ -242,17 +242,16 @@
 		]
 	},
 	"GateOut": {
-		"map_init": "{name}.pin  = daisy::patch_sm::DaisyPatchSM::{pin};\n\t\t{name}.mode = {mode};\n\t\t{name}.pull = {pull};\n\t\tdsy_gpio_init(&{name});",
-		"typename": "dsy_gpio",
-		"direction": "out",
-		"pin": "a",
-		"default_prefix": "som.",
-		"mode": "DSY_GPIO_MODE_OUTPUT_PP",
-		"pull": "DSY_GPIO_NOPULL",
+		"map_init": "{name}.Init(daisy::patch_sm::DaisyPatchSM::{pin}, daisy::GPIO::Mode::{mode}, daisy::GPIO::Pull::{pull}, daisy::GPIO::Speed::{speed});",
+		"typename": "daisy::GPIO",
+		"pin": "",
+		"mode": "OUTPUT",
+		"pull": "NOPULL",
+		"speed": "LOW",
 		"mapping": [
 			{
 				"name": "{name}",
-				"set": "dsy_gpio_write(&{class_name}.{default_prefix}{name}, {value});"
+				"set": "{class_name}.Write({value});"
 			}
 		]
 	},

--- a/src/json2daisy/templates/daisy.h
+++ b/src/json2daisy/templates/daisy.h
@@ -360,9 +360,7 @@ struct Daisy{{ name|capitalize }} {
 
   /** This is the board's "System On Module" */
   {{som_class}} som;
-  {% if som == 'seed' %}
   daisy::AdcChannelConfig cfg[ANALOG_COUNT];
-  {% endif %}
 
   // I/O Components
   {{comps}}


### PR DESCRIPTION
The previous PR https://github.com/Center-Abstract-Concrete-Machines/json2daisy/pull/1  added necessary fixes to be able to generate a header file without crashing the `json2daisy` program. However, it was not until I actually attempted to build a program using the estuary that I realized the header itself did not compile. 

Tomorrow I am hoping to make a "kitchen sink" equivalent for the estuary module (initializing all onboard hardware), so it's possible an additional follow up PR will follow this one.